### PR TITLE
change function utf8_encode() to iconv() for support php7

### DIFF
--- a/Classes.php
+++ b/Classes.php
@@ -44,7 +44,7 @@ class Vatsim
 
         foreach ($file as $ifile) {
             if (substr($ifile, 0, 1) != ";") {
-                $ifile = utf8_decode(rtrim($ifile));
+                $ifile = iconv("ISO-8859-1", "UTF-8", rtrim($ifile));
                 if ($allowed == true && substr($ifile, 0, 1) != "!") {
                     $data[] = self::parseAssociative(explode(":", $ifile));
                 } else {

--- a/json.php
+++ b/json.php
@@ -5,8 +5,8 @@ $obj = new Classes\Vatsim;
 
 /* Here you can choose what you want to show */
 
-$airlinePilots = $obj->showByAirline('TCA');
-//$allATC = $obj->showType('ATC');
+//$airlinePilots = $obj->showByAirline('TCA');
+$allATC = $obj->showType('ATC');
 //$allPilots = $obj->showType('PILOT');
 
-echo json_encode($airlinePilots);
+echo json_encode(array_values($allATC));


### PR DESCRIPTION
In my Environment, PHP7.2-dev shows following error message.

> PHP Fatal error:  Uncaught Error: Call to undefined function Classes\utf8_decode() in /var/www/html/vatsim/Classes.php:47

So, I changed utf8_encode() to iconv("ISO-8859-1", "UTF-8", args)

Reference
https://stackoverflow.com/questions/43925864/php7-0-call-to-undefined-function-utf8-encode